### PR TITLE
commons-beanutils を利用する処理において特定プロパティへのアクセスを抑制できるようにしました。

### DIFF
--- a/s2struts/src/main/java/org/seasar/struts/bean/SuppressPropertyUtilsBean.java
+++ b/s2struts/src/main/java/org/seasar/struts/bean/SuppressPropertyUtilsBean.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2004-2008 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.struts.bean;
+
+import java.beans.PropertyDescriptor;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.beanutils.PropertyUtilsBean;
+import org.apache.commons.collections.FastHashMap;
+
+/**
+ * 特定のプロパティへのアクセスを抑制します。
+ * 
+ * @author nakamura-to
+ *
+ */
+public class SuppressPropertyUtilsBean extends PropertyUtilsBean {
+
+    private static final String DEFAULT_PROPERTY_TO_SUPPRESS = "class";
+
+    private final Collection propertiesToSuppress;
+
+    private final FastHashMap descriptorsCache;
+
+    /**
+     * インスタンスを構築します。
+     * <p>
+     * このコンストラクタの呼び出しは、デフォルトで<code>class</code>プロパティへのアクセスを抑制します。
+     * </p>
+     */
+    public SuppressPropertyUtilsBean() {
+        this(DEFAULT_PROPERTY_TO_SUPPRESS);
+    }
+
+    /**
+     * 抑制対象のプロパティを1つ指定してインスタンスを構築します。
+     * 
+     * @param propertyToSuppress
+     *            抑制対象のプロパティ
+     */
+    public SuppressPropertyUtilsBean(String propertyToSuppress) {
+        this(toCollection(propertyToSuppress));
+    }
+
+    /**
+     * 抑制対象のプロパティのコレクションを指定してインスタンスを構築します。
+     * 
+     * @param propertiesToSuppress
+     *            抑制対象のプロパティのコレクション
+     */
+    public SuppressPropertyUtilsBean(Collection propertiesToSuppress) {
+        if (propertiesToSuppress == null) {
+            this.propertiesToSuppress = Collections.EMPTY_SET;
+        } else {
+            this.propertiesToSuppress = Collections.unmodifiableCollection(new HashSet(propertiesToSuppress));
+        }
+        descriptorsCache = new FastHashMap();
+        descriptorsCache.setFast(true);
+    }
+
+    private static Collection toCollection(String propertyToSuppress) {
+        Set set = new HashSet();
+        set.add(propertyToSuppress);
+        return set;
+    }
+
+    public PropertyDescriptor[] getPropertyDescriptors(Class beanClass) {
+        PropertyDescriptor[] descriptors = (PropertyDescriptor[]) descriptorsCache.get(beanClass);
+        if (descriptors != null) {
+            return descriptors;
+        }
+        descriptors = filter(super.getPropertyDescriptors(beanClass));
+        descriptorsCache.put(beanClass, descriptors);
+        return descriptors;
+    }
+
+    private PropertyDescriptor[] filter(PropertyDescriptor[] descriptors) {
+        List validDescriptors = new ArrayList();
+        for (int i = 0; i < descriptors.length; i++) {
+            if (descriptors[i] == null) {
+                continue;
+            }
+            if (propertiesToSuppress.contains(descriptors[i].getName())) {
+                continue;
+            }
+            validDescriptors.add(descriptors[i]);
+        }
+        return (PropertyDescriptor[]) validDescriptors.toArray(new PropertyDescriptor[validDescriptors.size()]);
+    }
+}

--- a/s2struts/src/main/java/org/seasar/struts/filter/S2StrutsFilter.java
+++ b/s2struts/src/main/java/org/seasar/struts/filter/S2StrutsFilter.java
@@ -25,6 +25,9 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.seasar.struts.bean.SuppressPropertyUtilsBean;
 import org.seasar.struts.util.RequestUtil;
 import org.seasar.struts.util.S2StrutsContextUtil;
 
@@ -59,6 +62,8 @@ public class S2StrutsFilter implements Filter {
     }
 
     public void init(FilterConfig config) throws ServletException {
+        BeanUtilsBean beanUtilsBean = new BeanUtilsBean(new ConvertUtilsBean(), new SuppressPropertyUtilsBean());
+        BeanUtilsBean.setInstance(beanUtilsBean);
     }
 
     public void destroy() {

--- a/s2struts/src/test/java/org/seasar/struts/bean/SuppressPropertyUtilsBeanTest.java
+++ b/s2struts/src/test/java/org/seasar/struts/bean/SuppressPropertyUtilsBeanTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2004-2008 the Seasar Foundation and the Others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, 
+ * either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.seasar.struts.bean;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import junit.framework.TestCase;
+
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.ConvertUtilsBean;
+import org.apache.commons.beanutils.PropertyUtilsBean;
+
+/**
+ * @author nakamura-to
+ *
+ */
+public class SuppressPropertyUtilsBeanTest extends TestCase {
+
+    public void testGetProperty() throws Exception {
+        PropertyUtilsBean propertyUtils = new SuppressPropertyUtilsBean("fullName");
+        Person person = new Person();
+        person.getFullName().setFirstName("aaa");
+        person.getFullName().setLastName("bbb");
+        person.getAddress().setStreet("ccc");
+        person.setAge("20");
+        try {
+            propertyUtils.getProperty(person, "fullName.firstName");
+        } catch (NoSuchMethodException expected) {
+        }
+        try {
+            propertyUtils.getProperty(person, "fullName.lastName");
+        } catch (NoSuchMethodException expected) {
+        }
+        assertEquals("ccc", propertyUtils.getProperty(person, "address.street"));
+        assertEquals("20", propertyUtils.getProperty(person, "age"));
+    }
+
+    public void testDescribe() throws Exception {
+        PropertyUtilsBean propertyUtils = new SuppressPropertyUtilsBean("fullName");
+        Person person = new Person();
+        Map properties = propertyUtils.describe(person);
+        assertEquals(3, properties.size());
+        assertTrue(properties.containsKey("address"));
+        assertTrue(properties.containsKey("age"));
+        assertTrue(properties.containsKey("class"));
+    }
+
+    public void testBeanUtilsBean_default_populate() throws Exception {
+        BeanUtilsBean beanUtils = new BeanUtilsBean();
+        Person person = new Person();
+        Map properties = new HashMap();
+        properties.put("fullName.firstName", "aaa");
+        properties.put("fullName.lastName", "bbb");
+        properties.put("address.street", "ccc");
+        properties.put("age", "20");
+        beanUtils.populate(person, properties);
+        assertEquals("aaa", person.getFullName().getFirstName());
+        assertEquals("bbb", person.getFullName().getLastName());
+        assertEquals("ccc", person.getAddress().getStreet());
+        assertEquals("20", person.getAge());
+    }
+
+    public void testBeanUtilsBean_suppressed_populate() throws Exception {
+        BeanUtilsBean beanUtils = new BeanUtilsBean(new ConvertUtilsBean(), new SuppressPropertyUtilsBean("fullName"));
+        Person person = new Person();
+        Map properties = new HashMap();
+        properties.put("fullName.firstName", "aaa");
+        properties.put("fullName.lastName", "bbb");
+        properties.put("address.street", "ccc");
+        properties.put("age", "20");
+        beanUtils.populate(person, properties);
+        assertNull(person.getFullName().getFirstName());
+        assertNull(person.getFullName().getLastName());
+        assertEquals("ccc", person.getAddress().getStreet());
+        assertEquals("20", person.getAge());
+    }
+
+    public class Person {
+        private FullName fullName = new FullName();
+
+        private Address address = new Address();
+
+        private String age;
+
+        public FullName getFullName() {
+            return fullName;
+        }
+
+        public void setFullName(FullName fullName) {
+            this.fullName = fullName;
+        }
+
+        public Address getAddress() {
+            return address;
+        }
+
+        public void setAddress(Address address) {
+            this.address = address;
+        }
+
+        public String getAge() {
+            return age;
+        }
+
+        public void setAge(String age) {
+            this.age = age;
+        }
+    }
+
+    public static class FullName {
+        private String firstName;
+
+        private String lastName;
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public void setFirstName(String firstName) {
+            this.firstName = firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public void setLastName(String lastName) {
+            this.lastName = lastName;
+        }
+    }
+
+    public static class Address {
+        private String street;
+
+        public String getStreet() {
+            return street;
+        }
+
+        public void setStreet(String street) {
+            this.street = street;
+        }
+    }
+}


### PR DESCRIPTION
デフォルトでは `class` プロパティへのアクセスを抑制します。
